### PR TITLE
Fractions Skill Score Addition

### DIFF
--- a/hwt/__init__.py
+++ b/hwt/__init__.py
@@ -1,6 +1,6 @@
-import version
-import plot
-from cfuncs import *
+from hwt import version
+from hwt import plot
+from hwt.cfuncs import *
 
 __all__ = ["cfuncs"]
 

--- a/hwt/cfuncs/__init__.py
+++ b/hwt/cfuncs/__init__.py
@@ -1,11 +1,11 @@
-import bin
-import neighborhood
-import verification
-import smoothers
-import miscfuncs
-import ensemble
-import objects
-import initiation_detection
+from hwt.cfuncs import bin
+from hwt.cfuncs import neighborhood
+from hwt.cfuncs import verification
+from hwt.cfuncs import smoothers
+from hwt.cfuncs import miscfuncs
+from hwt.cfuncs import ensemble
+from hwt.cfuncs import objects
+from hwt.cfuncs import initiation_detection
 
 __all__ = ["bin", "neighborhood", "verification", "smoothers", "miscfuncs",
            "ensemble", "objects", "initiation_detection"]

--- a/hwt/cfuncs/verification.pyx
+++ b/hwt/cfuncs/verification.pyx
@@ -1,6 +1,10 @@
 cimport cython
 import numpy as np
 cimport numpy as np
+import pdb
+
+cdef extern from 'math.h':
+    float sqrt(float x)
 
 
 DTYPE = np.int
@@ -99,7 +103,7 @@ def get_contingency(np.ndarray[DTYPE64_t, ndim=2] fcst,
 @cython.boundscheck(False)
 @cython.cdivision(True)
 cdef get_fss_fraction(np.ndarray[DTYPE_t, ndim=2] data, 
-                                     unsigned int roi):
+                                     unsigned int n):
     
     cdef Py_ssize_t i, j, ii, jj
     cdef unsigned int xlen = data.shape[0]
@@ -113,21 +117,64 @@ cdef get_fss_fraction(np.ndarray[DTYPE_t, ndim=2] data,
     for i in xrange(xlen):
         # xlen/ylen - 1 to give proper index value
         # for min functions
-        rxx = min(xlen -1, i + roi)
-        rxn = max(0, i - roi)
+        rxx = min(xlen -1, i + n)
+        rxn = max(0, i - n)
         for j in xrange(ylen):
-            ryx = min(ylen - 1, j + roi)
-            ryn = max(0, j - roi)
+            ryx = min(ylen - 1, j + n)
+            ryn = max(0, j - n)
             # rxx/ryx + 1 to be included in xrange
             for ii in xrange(rxn, rxx + 1):
                 for jj in xrange(ryn, ryx + 1):
                     if data[ii, jj] == 1:
                         frac[i, j ] += 1
 
-    frac = frac/roi**2
+    frac = frac/(n*n)
 
     return frac
 
+
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef get_fss_cfraction(np.ndarray[DTYPE_t, ndim=2] data,
+                                       float roi,
+                                       float dx):
+
+    cdef unsigned int xlen = data.shape[0]
+    cdef unsigned int ylen = data.shape[1]
+    cdef unsigned int ng
+    cdef int jw, je, isouth, inorth, n
+    cdef float rng, distsq, dist
+    cdef Py_ssize_t i, j, ii, jj
+
+    cdef np.ndarray[DTYPE64_t, ndim=2] frac = np.zeros([xlen, ylen], dtype=DTYPE64)
+    n = 0
+
+    rng = roi/dx
+    ng = int(rng)
+
+    for i in range(xlen):
+        isouth = i-ng
+        inorth = i+ng + 1
+        for j in range(ylen):
+            jw = j-ng
+            je = j+ng + 1
+            for ii in range(isouth, inorth):
+                for jj in range(jw, je):
+                    if jw < 0 or je >= ylen or isouth < 0 or inorth >= xlen:
+                        continue
+                    distsq = float(j-jj)*float(j-jj)  + float(i-ii)*float(i-ii)
+                    dist = sqrt(distsq)
+                    if dist <= rng:
+                        n += 1
+                        if data[ii, jj] == 1:
+                            frac[i,j] += 1
+
+    if n == 0:
+        raise ValueError('No points in neighborhood. Check radius and grid spacing.')
+    else:
+        frac = frac/float(n)
+
+    return frac
 
 
 @cython.boundscheck(False)
@@ -137,7 +184,7 @@ cdef get_fss_mse(np.ndarray[DTYPE64_t, ndim = 2] obs,
 
     cdef Py_ssize_t i, j
     cdef unsigned int nx, ny
-    cdef double mse = 0
+    cdef float mse = 0
 
     if (obs.shape[0] != fcst.shape[0]) or (obs.shape[1] != fcst.shape[1]):
         raise ValueError('Observation and forecast arrays must be the same shape.')
@@ -174,26 +221,73 @@ cdef get_fss_ref(np.ndarray[DTYPE64_t, ndim = 2] obs,
         for j in xrange(ny):
             ref = ref + obs[i,j]*obs[i,j] + fcst[i,j]*fcst[i,j]
 
-    ref = ref/(nx/ny)
+    ref = ref/(nx*ny)
 
     return ref
 
 
 
-def fss(obs, fcst, n = 0):
+def fss(obs, fcst, r = None, dx = None, neighborhood = None):
+    """
+    Calculate Fractions Skill Score.
 
-    if n < 0:
-        raise ValueError('Neighborhood radius cannot be negative.')
+    Parameters
+    ----------
+    obs : Observation binary array
+    fcst : Forecast binary array
+    r : For a square neighborhood, radius in grid points. For
+        a circle neighborhood, radius of influence in kilometers.
+    dx : Grid spacing. This is only relevant for circular
+        neighborhoods.
+    neighborhood : Shape of neighborhood to calculate
+        fraction of hits. Options are 'square' or 'circle'. Default
+        is None which simply does a grid point to grid point 
+        comparison.
 
-    if n > 0:
-        ofrac = get_fss_fraction(obs, n)
-        ffrac = get_fss_fraction(fcst, n)
+    Returns
+    -------
+    fss : scalar
 
-        mse = get_fss_mse(ofrac, ffrac)
-        ref = get_fss_ref(ofrac, ffrac)
-    else:
+    Raises
+    ------
+    ValueError
+        The neighborhood size is negative, the input arrays are
+        difference sizes, or the neighborhood type is unknown.
+
+    Notes
+    -----
+    - Square neighborhoods do not use any distance calculations. They
+        simply have r grid points beyond each point in their neighborhood.
+    - Circle neighborhoods do use distance (via dx) to calculate a true
+        radius of influence.
+    """
+
+    if neighborhood is None:
+        obs = obs.astype(np.float64)
+        fcst = fcst.astype(np.float64)
         mse = get_fss_mse(obs, fcst)
         ref = get_fss_ref(obs, fcst)
+    elif neighborhood == 'square':
+        if r <= 0:
+            raise ValueError('Neighborhood radius must be non-zero and positive.')
+        else:
+            ofrac = get_fss_fraction(obs, r)
+            ffrac = get_fss_fraction(fcst, r)
+            mse = get_fss_mse(ofrac, ffrac)
+            ref = get_fss_ref(ofrac, ffrac)
+    elif neighborhood == 'circle':
+        if dx is None or r is None:
+            raise ValueError('Missing grid spacing or radius.')
+        else:
+            if dx <= 0 or r <= 0:
+                raise ValueError('Grid spacing and radius must be non-zero and positive.')
+            else:
+                ofrac = get_fss_cfraction(obs, r, dx)
+                ffrac = get_fss_cfraction(fcst, r, dx)
+                mse = get_fss_mse(ofrac, ffrac)
+                ref = get_fss_ref(ofrac, ffrac)
+    else:
+        raise ValueError('Invalid neighborhood type.')
 
     fss = 1 - mse/ref
 

--- a/hwt/cfuncs/verification.pyx
+++ b/hwt/cfuncs/verification.pyx
@@ -288,6 +288,9 @@ def fss(obs, fcst, r = None, dx = None, neighborhood = None):
     else:
         raise ValueError('Invalid neighborhood type.')
 
-    fss = 1 - mse/ref
+    if ref == 0:
+        fss = np.nan
+    else:
+        fss = 1 - mse/ref
 
     return fss

--- a/hwt/cfuncs/verification.pyx
+++ b/hwt/cfuncs/verification.pyx
@@ -1,7 +1,6 @@
 cimport cython
 import numpy as np
 cimport numpy as np
-import pdb
 
 cdef extern from 'math.h':
     float sqrt(float x)

--- a/hwt/plot/__init__.py
+++ b/hwt/plot/__init__.py
@@ -1,2 +1,2 @@
-import ctables
-import funcs
+from hwt.plot import ctables
+from hwt.plot import funcs

--- a/hwt/plot/ctables.py
+++ b/hwt/plot/ctables.py
@@ -1763,7 +1763,7 @@ _Positive_Definite_data = {
 
     
 datad = {}
-for name in locals().keys():
+for name in list(locals().keys()):
     if name.endswith('_data'):
         newname = name[1:-5]
         

--- a/hwt/version.py
+++ b/hwt/version.py
@@ -70,7 +70,7 @@ def get_version():
     version = __version__
     if not release:
         try:
-            import __git_version__
+            from hwt import __git_version__
             version += __git_version__.rev
         except ImportError:
             version += get_git_revision()


### PR DESCRIPTION
The FSS calculations are all cythonized. The calculation can handle the traditional square neighborhood or a circular neighborhood. Neighborhood fractions can be skipped as well allowing for input of Practically Perfect observation and forecast grids.
